### PR TITLE
Change the way of visiting pages on splinter driver.

### DIFF
--- a/pyfunct/contrib/splinter_driver.py
+++ b/pyfunct/contrib/splinter_driver.py
@@ -51,7 +51,7 @@ class SplinterBrowserDriver(BaseBrowserDriver):
         return self._browser.title
 
     def open_url(self, url):
-        self._browser.visit(url)
+        self._browser.driver.get(url)
 
     def quit(self):
         return self._browser.quit()

--- a/tests/contrib/test_splinter_driver.py
+++ b/tests/contrib/test_splinter_driver.py
@@ -60,7 +60,7 @@ class SplinterBrowserDriverTestCase(unittest.TestCase):
 
         driver.open_url(url)
 
-        mocked_browser.visit.assert_called_once_with(url)
+        mocked_browser.driver.get.assert_called_once_with(url)
 
     @patch('pyfunct.contrib.splinter_driver.Browser')
     def test_quit(self, mocked_browser):


### PR DESCRIPTION
Make this because splinter raises errors by default when accessing an error page, and testing error pages is wanted sometimes.
