### PR TITLE
Adds mouse_out and fixes test cases

### DIFF
--- a/pyfunct/browsers.py
+++ b/pyfunct/browsers.py
@@ -163,6 +163,12 @@ class BaseBrowserDriver(object):
         """
         raise NotImplementedError("This browser doesn't support mouse over.")
 
+    def mouse_out(self, element):
+        """
+            Simulates an element mouse out.
+        """
+        raise NotImplementedError("This browser doesn't support mouse out.")
+
     def open_url(self, url):
         """
             Opens an URL and returns it's response.

--- a/pyfunct/contrib/splinter_driver.py
+++ b/pyfunct/contrib/splinter_driver.py
@@ -128,6 +128,10 @@ class SplinterBrowserDriver(BaseBrowserDriver):
     def mouse_over(self, element):
         return element.mouse_over()
 
+    @element_action
+    def mouse_out(self, element):
+        return element.mouse_out()
+
     def reload(self):
         return self._browser.reload()
 

--- a/tests/contrib/test_splinter_driver.py
+++ b/tests/contrib/test_splinter_driver.py
@@ -227,6 +227,17 @@ class SplinterBrowserDriverTestCase(unittest.TestCase):
         element.mouse_over.assert_called_once_with()
 
     @patch('pyfunct.contrib.splinter_driver.Browser')
+    def test_mouse_out(self, mocked_browser):
+
+        driver = self._get_driver(mocked_browser)
+
+        element = Mock()
+
+        driver.mouse_out(element)
+
+        element.mouse_out.assert_called_once_with()
+
+    @patch('pyfunct.contrib.splinter_driver.Browser')
     def test_check(self, mocked_browser):
 
         driver = self._get_driver(mocked_browser)


### PR DESCRIPTION
Implements the mouse_out method for the splinter driver and adds it to the interface. Additionally, fixes test cases that were producing false positives due to the usage of "assert_called()" instead of "assert_called_(once_)with())
