### PR TITLE
Quit browsers between tests

### DIFF
--- a/pyfunct/case.py
+++ b/pyfunct/case.py
@@ -41,9 +41,7 @@ class FunctTestCase(unittest.TestCase):
             if self.reuse_browser and browser == cls.browser:
                 browser.clear_session()
             else:
-                browser.quit()
-
-        cls.browsers = [cls.browser] if self.reuse_browser else []
+                self.quit_browser(browser)
 
     def create_browser(self, driver_name=None, *args, **kwargs):
         """
@@ -55,6 +53,10 @@ class FunctTestCase(unittest.TestCase):
         browser = REGISTERED_DRIVERS[driver_name](*args, **kwargs)
         self.__class__.browsers.append(browser)
         return browser
+
+    def quit_browser(self, browser):
+        browser.quit()
+        self.__class__.browsers.remove(browser)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_testcase.py
+++ b/tests/test_testcase.py
@@ -130,6 +130,8 @@ class FunctTestCaseTestCase(unittest.TestCase):
         self.assertEqual(driver.quit_call_count, 0)
         self.assertEqual(driver.clear_session_call_count, 0)
 
+        self.assertEqual([testcase.browser, driver], testcase.browsers)
+
         testcase.tearDown()
 
         # assert that, after teardown, the browser was quitted
@@ -154,6 +156,8 @@ class FunctTestCaseTestCase(unittest.TestCase):
         # assert that no quit calls were made before teardown
         self.assertEqual(driver.quit_call_count, 0)
         self.assertEqual(driver.clear_session_call_count, 0)
+
+        self.assertEqual([driver], testcase.browsers)
 
         testcase.tearDown()
 


### PR DESCRIPTION
Before, pyfuct only quits browsers on end of testcase (`tearDownClass`).
This will avoid keep multiple browsers open, that aren't used.

In case property `reuse_browser` is configured to true, we mantain only
the default browser open and clear his session.
